### PR TITLE
Add Tx Ibus support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /build-*
 /tmp
+/.vscode

--- a/main/config/config.h
+++ b/main/config/config.h
@@ -24,6 +24,7 @@ typedef enum
 typedef enum
 {
     TX_INPUT_CRSF,
+    TX_INPUT_IBUS,
     TX_INPUT_FAKE,
     TX_INPUT_FIRST = TX_INPUT_CRSF,
 #if defined(CONFIG_RAVEN_FAKE_INPUT)

--- a/main/config/settings.c
+++ b/main/config/settings.c
@@ -314,7 +314,7 @@ static const char *air_band_table[] = {
 };
 _Static_assert(ARRAY_COUNT(air_band_table) == CONFIG_AIR_BAND_COUNT, "Invalid air band names table");
 #if defined(USE_TX_SUPPORT)
-static const char *tx_input_table[] = {"CRSF", "Test"};
+static const char *tx_input_table[] = {"CRSF", "IBUS", "Test"};
 #endif
 static const char *air_rf_power_table[] = {"Auto", "1mw", "10mw", "25mw", "50mw", "100mw"};
 _Static_assert(ARRAY_COUNT(air_rf_power_table) == AIR_RF_POWER_LAST - AIR_RF_POWER_FIRST + 1, "air_rf_power_table invalid");

--- a/main/config/settings.c
+++ b/main/config/settings.c
@@ -157,9 +157,9 @@ static setting_visibility_e setting_visibility_tx(folder_id_e folder, settings_v
     }
     if (SETTING_IS(setting, SETTING_KEY_TX_TX_GPIO))
     {
-        // Don't allow changing the TX pin from the CRSF configuration scripts
+        // Don't allow changing the TX pin from the CRSF/IBUS configuration scripts
         // since it will break communication.
-        return SETTING_SHOW_IF(config_get_input_type() == TX_INPUT_CRSF && view_id != SETTINGS_VIEW_CRSF_INPUT);
+        return SETTING_SHOW_IF(config_get_input_type() != TX_INPUT_FAKE && view_id != SETTINGS_VIEW_CRSF_INPUT);
     }
     if (SETTING_IS(setting, SETTING_KEY_TX_RX_GPIO))
     {

--- a/main/input/input_ibus.c
+++ b/main/input/input_ibus.c
@@ -1,0 +1,187 @@
+#include <stdio.h>
+
+#include <hal/log.h>
+
+#include "config/settings_rmp.h"
+
+#include "rc/rc_data.h"
+
+#include "rmp/rmp.h"
+
+#include "util/version.h"
+
+#include "input_ibus.h"
+
+static const char *TAG = "IBUS.Input";
+
+#define BPS_DETECT_SWITCH_INTERVAL_US MILLIS_TO_MICROS(1000)
+#define BPS_FALLBACK_INTERVAL SECS_TO_MICROS(1)
+#define RESPONSE_WAIT_INTERVAL_US (500)
+
+static uint16_t input_ibus_channel_value_mapping(uint16_t ch)
+{
+    return RC_CHANNEL_MIN_VALUE +
+           (ch - IBUS_CHANNEL_VALUE_MIN) * (RC_CHANNEL_MAX_VALUE - RC_CHANNEL_MIN_VALUE) /
+               (IBUS_CHANNEL_VALUE_MAX - IBUS_CHANNEL_VALUE_MIN);
+}
+
+static void input_ibus_isr(const serial_port_t *port, uint8_t b, void *user_data)
+{
+    input_ibus_t *input = user_data;
+    // Received byte in TX mode
+    time_micros_t now = time_micros_now();
+    input->last_byte_at = now;
+
+    ibus_port_t *ibusport = &input->ibus;
+
+    if (ibusport->buf_pos < sizeof(ibusport->buf))
+    {
+        ibusport->buf[ibusport->buf_pos++] = b;
+    }
+}
+
+//no recv after this us time indicates that a tx frame is done
+static unsigned input_ibus_tx_done_timeout_us(input_ibus_t *input)
+{
+    return 2000;
+}
+
+static unsigned input_ibus_frame_interval_us(input_ibus_t *input)
+{
+    return 7000;
+}
+
+static void input_ibus_frame_callback(void *data, ibus_frame_t *frame)
+{
+    input_ibus_t *input_ibus = data;
+    time_micros_t now = time_micros_now();
+    switch (frame->payload.pack_type)
+    {
+    case IBUS_FRAMETYPE_RC_CHANNELS:
+    {
+        for (int i = 0; i < IBUS_NUM_CHANNELS; i++)
+        {
+            rc_data_update_channel(input_ibus->input.rc_data, i, 
+                input_ibus_channel_value_mapping(frame->payload.ch[i]), now);
+        }
+        break;
+    }
+    default:
+        LOG_W(TAG, "Unknown frame type 0x%02x with size %u", frame->payload.pack_type, frame->payload.pack_len);
+        LOG_BUFFER_W(TAG, frame, frame->payload.pack_len);
+    }
+
+    // Note that we always should get a frame with the same period. When there's extra data from
+    // the radio (e.g. an MSP request), it will replace control frames.
+    unsigned frame_interval = input_ibus_frame_interval_us(input_ibus);
+    if (frame_interval > 0)
+    {
+        if (input_ibus->last_frame_recv > 0 && now - input_ibus->last_frame_recv > frame_interval * 1.5f)
+        {
+            LOG_W(TAG, "Lost a frame, interval between 2 was %llu", now - input_ibus->last_frame_recv);
+        }
+    }
+    input_ibus->last_frame_recv = now;
+}
+
+static bool input_ibus_open(void *input, void *config)
+{
+    input_ibus_config_t *config_ibus = config;
+    input_ibus_t *input_ibus = input;
+    input_ibus->bps = IBUS_INPUT_BPS_DETECT;
+
+    LOG_I(TAG, "Open");
+
+    io_t ibus_io = {
+        .read = NULL,
+        .write = NULL,
+        .data = input,
+    };
+
+    ibus_port_init(&input_ibus->ibus, &ibus_io, input_ibus_frame_callback, input);
+
+    serial_port_config_t serial_config = {
+        .baud_rate = IBUS_BAUDRATE,
+        .tx_pin = config_ibus->gpio,
+        .rx_pin = config_ibus->gpio,
+        .tx_buffer_size = 128,
+        .parity = SERIAL_PARITY_DISABLE,
+        .stop_bits = SERIAL_STOP_BITS_1,
+        .inverted = false,
+        .byte_callback = input_ibus_isr,
+        .byte_callback_data = input_ibus,
+    };
+
+    input_ibus->serial_port = serial_port_open(&serial_config);
+    input_ibus->baud_rate = serial_config.baud_rate;
+
+    time_micros_t now = time_micros_now();
+    input_ibus->telemetry_pos = 0;
+    input_ibus->last_byte_at = 0;
+    input_ibus->last_frame_recv = now;
+    input_ibus->next_resp_frame = TIME_MICROS_MAX;
+    input_ibus->enable_rx_deadline = TIME_MICROS_MAX;
+    input_ibus->bps_detect_switched = now;
+    input_ibus->gpio = config_ibus->gpio;
+
+    // 100ms should be low enough to be detected fast and high enough that
+    // it's not accidentally triggered in 115200bps mode.
+    failsafe_set_max_interval(&input_ibus->input.failsafe, MILLIS_TO_MICROS(100));
+    failsafe_reset_interval(&input_ibus->input.failsafe, now);
+
+    return true;
+}
+
+static bool input_ibus_update(void *input, rc_data_t *data, time_micros_t now)
+{
+    input_ibus_t *input_ibus = input;
+    bool updated = false;
+    if (input_ibus->last_byte_at > 0 && now > input_ibus->last_byte_at && (now - input_ibus->last_byte_at) > input_ibus_tx_done_timeout_us(input_ibus))
+    {
+        // Transmission from radio has ended. We either got a frame
+        // or corrupted data.
+        if (ibus_port_decode(&input_ibus->ibus))
+        {
+            failsafe_reset_interval(&input_ibus->input.failsafe, now);
+            updated = true;
+
+            // If we decode a request, send a response (either an scheduled one
+            // or a telemetry frame). Note that if we take more than 1s to resend the
+            // IBUS_FRAMETYPE_LINK_STATISTICS frame, it will cause an RSSI lost warning
+            // in the radio.
+            input_ibus->next_resp_frame = now + RESPONSE_WAIT_INTERVAL_US;
+        }
+        // XXX: For now, we always reset the IBUS decoder since sometimes
+        // when using RMP we might end up with several frames in the queue.
+        ibus_port_reset(&input_ibus->ibus);
+
+        input_ibus->last_byte_at = 0;
+    }
+
+    if (now > input_ibus->next_resp_frame)
+    {
+    }
+    return updated;
+}
+
+static void input_ibus_close(void *input, void *config)
+{
+    input_ibus_t *input_ibus = input;
+    if (input_ibus->rmp_port)
+    {
+        rmp_close_port(input_ibus->input.rc_data->rmp, input_ibus->rmp_port);
+        input_ibus->rmp_port = NULL;
+    }
+    serial_port_destroy(&input_ibus->serial_port);
+}
+
+void input_ibus_init(input_ibus_t *input)
+{
+    input->serial_port = NULL;
+    input->input.vtable = (input_vtable_t){
+        .open = input_ibus_open,
+        .update = input_ibus_update,
+        .close = input_ibus_close,
+    };
+    RING_BUFFER_INIT(&input->scheduled, ibus_frame_t, IBUS_INPUT_FRAME_QUEUE_SIZE);
+}

--- a/main/input/input_ibus.h
+++ b/main/input/input_ibus.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "config/settings.h"
+
+#include "io/gpio.h"
+#include "io/serial.h"
+
+#include "input/input.h"
+
+#include "msp/msp_telemetry.h"
+
+#include "protocols/ibus.h"
+
+#include "util/time.h"
+
+typedef struct rmp_port_s rmp_port_t;
+
+typedef enum
+{
+    IBUS_INPUT_BPS_DETECT,
+    IBUS_INPUT_BPS_400K,
+    IBUS_INPUT_BPS_115K,
+} ibus_input_bps_e;
+
+typedef struct input_ibus_config_s
+{
+    // IBUS input from radio is single line half duplex
+    hal_gpio_t gpio;
+} input_ibus_config_t;
+
+#define IBUS_INPUT_FRAME_QUEUE_SIZE 4
+#define IBUS_INPUT_ADDR_LIST_SIZE 8
+
+typedef struct input_ibus_s
+{
+    input_t input;
+    serial_port_t *serial_port;
+    ibus_input_bps_e bps;
+    time_micros_t last_byte_at;
+    time_micros_t last_frame_recv;
+    time_micros_t next_resp_frame;
+    time_micros_t enable_rx_deadline;
+    time_micros_t bps_detect_switched;
+    unsigned baud_rate;
+    ibus_port_t ibus;
+    hal_gpio_t gpio;
+    unsigned telemetry_pos;
+    const rmp_port_t *rmp_port;
+    uint8_t ping_filter;
+    RING_BUFFER_DECLARE(scheduled, ibus_frame_t, IBUS_INPUT_FRAME_QUEUE_SIZE);
+    msp_telemetry_t msp_telemetry;
+} input_ibus_t;
+
+void input_ibus_init(input_ibus_t *input);

--- a/main/protocols/ibus.c
+++ b/main/protocols/ibus.c
@@ -1,0 +1,76 @@
+#include "ibus.h"
+#include "rc/rc_data.h"
+#include <hal/log.h>
+#include <string.h>
+
+static const char *TAG = "IBUS";
+
+static bool ibus_frame_crc_check(ibus_frame_t *frame)
+{
+    uint16_t sum = 0;
+    for (int i = 0; i < sizeof(ibus_frame_t) - 2; i++)
+    {
+        sum += frame->bytes[i];
+    }
+    return sum + frame->payload.checksum == 0xffff;
+}
+
+void ibus_port_init(ibus_port_t *port, io_t *io, ibus_frame_f frame_callback, void *callback_data)
+{
+    port->io = *io;
+    port->frame_callback = frame_callback;
+    port->callback_data = callback_data;
+    port->buf_pos = 0;
+}
+
+void ibus_port_reset(ibus_port_t *port)
+{
+    port->buf_pos = 0;
+}
+
+bool ibus_port_decode(ibus_port_t *port)
+{
+    int start = 0;
+    int end = port->buf_pos;
+    bool found = false;
+
+    while (end - start >= 6)
+    {
+        size_t total_frame_size = port->buf[start];
+
+        if (end - start < total_frame_size)
+        {
+            // No more complete frames to decode
+            break;
+        }
+        //LOG_I(TAG, "Got frame of size %u", total_frame_size);
+        // We have a complete frame. Check checksum
+        ibus_frame_t *frame = (ibus_frame_t *)&port->buf[start];
+        if (ibus_frame_crc_check(frame))
+        {
+            found = true;
+            port->frame_callback(port->callback_data, frame);
+        }
+        else
+        {
+            LOG_W(TAG, "CRC error in frame with size %d.", total_frame_size);
+            LOG_BUFFER_W(TAG, frame, total_frame_size);
+        }
+        start += total_frame_size;
+    }
+    if (start > 0)
+    {
+        if (start > port->buf_pos)
+        {
+            LOG_E(TAG, "Error %d > %d", start, (int)port->buf_pos);
+        }
+        assert(start <= port->buf_pos);
+        if (start != port->buf_pos)
+        {
+            // Move remaining data to the front
+            memmove(port->buf, &port->buf[start], end - start);
+        }
+        port->buf_pos -= start;
+    }
+    return found;
+}

--- a/main/protocols/ibus.h
+++ b/main/protocols/ibus.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "io/io.h"
+
+#define IBUS_BAUDRATE 115200
+#define IBUS_NUM_CHANNELS 14
+#define IBUS_FRAME_SIZE_MAX 16 * 2 + 2 + 2
+#define IBUS_CHANNEL_VALUE_MIN 1000
+#define IBUS_CHANNEL_VALUE_MID 1500
+#define IBUS_CHANNEL_VALUE_MAX 2000
+
+typedef struct rc_data_s rc_data_t;
+
+typedef enum
+{
+    IBUS_FRAMETYPE_RC_CHANNELS = 0x40,
+} input_frame_type_e;
+
+typedef struct ibus_payload_s
+{
+    uint8_t pack_len : 8;
+    input_frame_type_e pack_type: 8;
+    uint16_t ch[IBUS_NUM_CHANNELS];
+    uint16_t checksum;
+} __attribute__((packed)) ibus_payload_t;
+
+typedef union {
+    uint8_t bytes[sizeof(ibus_payload_t)];
+    ibus_payload_t payload;
+} ibus_frame_t;
+
+typedef void (*ibus_frame_f)(void *data, ibus_frame_t *frame);
+
+typedef struct ibus_port_s
+{
+    io_t io;
+    ibus_frame_f frame_callback;
+    void *callback_data;
+    uint8_t buf[IBUS_FRAME_SIZE_MAX];
+    unsigned buf_pos;
+} ibus_port_t;
+
+// IBUS uses the same channel stepping and numbering as our internal representation,
+// just with +1 offset.
+inline unsigned channel_from_ibus_value(unsigned ibus_val) { return ibus_val - 1; }
+inline unsigned channel_to_ibus_value(unsigned val) { return val + 1; }
+
+void ibus_port_init(ibus_port_t *port, io_t *io, ibus_frame_f frame_callback, void *callback_data);
+
+bool ibus_port_decode(ibus_port_t *port);
+void ibus_port_reset(ibus_port_t *port);

--- a/main/rc/rc.c
+++ b/main/rc/rc.c
@@ -306,6 +306,11 @@ static void rc_reconfigure_input(rc_t *rc)
             input_config.crsf.gpio = settings_get_key_gpio(SETTING_KEY_TX_TX_GPIO);
             rc->input_config = &input_config.crsf;
             break;
+        case TX_INPUT_IBUS:
+            input_fake_init(&rc->inputs.fake);
+            rc->input = (input_t *)&rc->inputs.fake;
+            rc->input_config = NULL;
+            break;
         case TX_INPUT_FAKE:
             input_fake_init(&rc->inputs.fake);
             rc->input = (input_t *)&rc->inputs.fake;

--- a/main/rc/rc.c
+++ b/main/rc/rc.c
@@ -286,6 +286,7 @@ static void rc_reconfigure_input(rc_t *rc)
     LOG_I(TAG, "Reconfigure input");
     union {
         input_crsf_config_t crsf;
+        input_crsf_config_t ibus;
     } input_config;
     if (rc->input != NULL)
     {
@@ -307,9 +308,10 @@ static void rc_reconfigure_input(rc_t *rc)
             rc->input_config = &input_config.crsf;
             break;
         case TX_INPUT_IBUS:
-            input_fake_init(&rc->inputs.fake);
-            rc->input = (input_t *)&rc->inputs.fake;
-            rc->input_config = NULL;
+            input_ibus_init(&rc->inputs.ibus);
+            rc->input = (input_t *)&rc->inputs.ibus;
+            input_config.ibus.gpio = settings_get_key_gpio(SETTING_KEY_TX_TX_GPIO);
+            rc->input_config = &input_config.ibus;
             break;
         case TX_INPUT_FAKE:
             input_fake_init(&rc->inputs.fake);

--- a/main/rc/rc.h
+++ b/main/rc/rc.h
@@ -8,6 +8,7 @@
 #include "input/input_air.h"
 #include "input/input_air_bind.h"
 #include "input/input_crsf.h"
+#include "input/input_ibus.h"
 #include "input/input_fake.h"
 
 #include "output/output_air.h"
@@ -55,6 +56,7 @@ typedef struct rc_s
         input_air_t air;
         input_air_bind_t air_bind;
         input_crsf_t crsf;
+        input_ibus_t ibus;
         input_fake_t fake;
     } inputs;
     union {


### PR DESCRIPTION
Added IBus support for Tx, code mostly copied from the crossfire implementation.
This allows many Flysky uses to try Raven system without buying a new RC  ;)
Only Tx Input added, for ibus output is not that widely used, and we can use crsf, sbus or msp instead.
