### PR TITLE
Correctly initialize RSSI channel

### DIFF
--- a/main/output/output.c
+++ b/main/output/output.c
@@ -217,7 +217,7 @@ static void output_configure_rssi(output_t *output)
 {
     // TODO: This code and RSSI handling can be left out when no RX support is compiled in
     rx_rssi_channel_e rssi_channel = RX_RSSI_CHANNEL_NONE;
-    if (!OUTPUT_HAS_FLAG(output, OUTPUT_FLAG_REMOTE) && OUTPUT_HAS_FLAG(output, OUTPUT_FLAG_SENDS_RSSI))
+    if (!OUTPUT_HAS_FLAG(output, OUTPUT_FLAG_REMOTE) && !OUTPUT_HAS_FLAG(output, OUTPUT_FLAG_SENDS_RSSI))
     {
         const setting_t *rx_rssi_channel_setting = settings_get_key(SETTING_KEY_RX_RSSI_CHANNEL);
         if (rx_rssi_channel_setting)

--- a/main/output/output.h
+++ b/main/output/output.h
@@ -17,7 +17,7 @@ typedef enum
 {
     OUTPUT_FLAG_LOCAL = 0,           // Connected by cable to the FC/servos
     OUTPUT_FLAG_REMOTE = 1 << 0,     // Sends data over the air
-    OUTPUT_FLAG_SENDS_RSSI = 1 << 1, // Output sends RSSI to the FC
+    OUTPUT_FLAG_SENDS_RSSI = 1 << 1, // Output sends RSSI to the FC on its own (e.g. FPort)
 } output_flags_e;
 
 typedef struct output_vtable_s

--- a/main/output/output_fport.c
+++ b/main/output/output_fport.c
@@ -237,7 +237,7 @@ static void output_fport_close(void *output, void *config)
 
 void output_fport_init(output_fport_t *output)
 {
-    output->output.flags = OUTPUT_FLAG_LOCAL;
+    output->output.flags = OUTPUT_FLAG_LOCAL | OUTPUT_FLAG_SENDS_RSSI;
     output->output.vtable = (output_vtable_t){
         .open = output_fport_open,
         .update = output_fport_update,


### PR DESCRIPTION
Check for wether the output already reported the RSSI was inverted
and the channel was never set up.

Also, add the flag to the FPort output and document the
OUTPUT_FLAG_SENDS_RSSI a bit better.

Thanks to @nmaggioni for spotting it

Fixes #30