### PR TITLE
Add support for SX127X modules with EN lines for TX/RX

### DIFF
--- a/main/io/sx127x.c
+++ b/main/io/sx127x.c
@@ -179,6 +179,16 @@ static void sx127x_set_mode(sx127x_t *sx127x, uint8_t mode)
     {
         sx127x_write_reg(sx127x, REG_OP_MODE, mode);
         sx127x->state.mode = mode;
+
+        if (sx127x->txen != HAL_GPIO_NONE)
+        {
+            HAL_ERR_ASSERT_OK(hal_gpio_set_level(sx127x->txen, (mode & MODE_TX) ? HAL_GPIO_HIGH : HAL_GPIO_LOW));
+        }
+
+        if (sx127x->rxen != HAL_GPIO_NONE)
+        {
+            HAL_ERR_ASSERT_OK(hal_gpio_set_level(sx127x->rxen, (mode & MODE_RX_CONTINUOUS) ? HAL_GPIO_HIGH : HAL_GPIO_LOW));
+        }
     }
 }
 
@@ -289,6 +299,18 @@ void sx127x_init(sx127x_t *sx127x)
 {
     HAL_ERR_ASSERT_OK(hal_gpio_setup(sx127x->rst, HAL_GPIO_DIR_OUTPUT, HAL_GPIO_PULL_NONE));
     sx127x_reset(sx127x);
+
+    if (sx127x->txen != HAL_GPIO_NONE)
+    {
+        HAL_ERR_ASSERT_OK(hal_gpio_setup(sx127x->txen, HAL_GPIO_DIR_OUTPUT, HAL_GPIO_PULL_NONE));
+        HAL_ERR_ASSERT_OK(hal_gpio_set_level(sx127x->txen, HAL_GPIO_LOW));
+    }
+
+    if (sx127x->rxen != HAL_GPIO_NONE)
+    {
+        HAL_ERR_ASSERT_OK(hal_gpio_setup(sx127x->rxen, HAL_GPIO_DIR_OUTPUT, HAL_GPIO_PULL_NONE));
+        HAL_ERR_ASSERT_OK(hal_gpio_set_level(sx127x->rxen, HAL_GPIO_LOW));
+    }
 
     // Initialize the SPI bus
     HAL_ERR_ASSERT_OK(hal_spi_bus_init(sx127x->spi_bus, sx127x->miso, sx127x->mosi, sx127x->sck));

--- a/main/io/sx127x.h
+++ b/main/io/sx127x.h
@@ -71,6 +71,8 @@ typedef struct sx127x_s
     const hal_gpio_t cs;
     const hal_gpio_t rst;
     const hal_gpio_t dio0;
+    const hal_gpio_t txen;
+    const hal_gpio_t rxen;
     const sx127x_output_type_e output_type;
     struct
     {

--- a/main/main.c
+++ b/main/main.c
@@ -56,6 +56,16 @@ static air_radio_t radio = {
     .sx127x.cs = SX127X_GPIO_CS,
     .sx127x.rst = SX127X_GPIO_RST,
     .sx127x.dio0 = SX127X_GPIO_DIO0,
+#if defined(SX127X_GPIO_TXEN)
+    .sx127x.txen = SX127X_GPIO_TXEN,
+#else
+    .sx127x.txen = HAL_GPIO_NONE,
+#endif
+#if defined(SX127X_GPIO_RXEN)
+    .sx127x.rxen = SX127X_GPIO_RXEN,
+#else
+    .sx127x.rxen = HAL_GPIO_NONE,
+#endif
     .sx127x.output_type = SX127X_OUTPUT_TYPE,
 #endif
 };


### PR DESCRIPTION
Platforms using them must define SX127X_GPIO_TXEN and
SX127X_GPIO_RXEN to some GPIO pins. e.g.

Driver will initially set both pins as low, toggling them as
needed when the mode of the radio changes.