### PR TITLE
Show RX pin selection for SBUS input protocol

### DIFF
--- a/main/config/settings.c
+++ b/main/config/settings.c
@@ -179,7 +179,7 @@ static setting_visibility_e setting_visibility_tx(folder_id_e folder, settings_v
     }
     if (SETTING_IS(setting, SETTING_KEY_TX_RX_GPIO))
     {
-        return SETTING_SHOW_IF(config_get_input_type() == TX_INPUT_IBUS || config_get_input_type() == TX_INPUT_PPM);
+        return SETTING_SHOW_IF(config_get_input_type() == TX_INPUT_IBUS || config_get_input_type() == TX_INPUT_PPM || config_get_input_type() == TX_INPUT_SBUS);
     }
 #endif
     return SETTING_VISIBILITY_SHOW;


### PR DESCRIPTION
RX Pin setting wasn't shown when SBUS was chosen as input protocol.